### PR TITLE
Fixes package

### DIFF
--- a/requests_throttler/example.py
+++ b/requests_throttler/example.py
@@ -32,9 +32,9 @@ def main():
         throttled_requests = bt.multi_submit(reqs)
 
     for r in throttled_requests:
-        print r.response
+        print(r.response)
 
-    print "Success: {s}, Failures: {f}".format(s=bt.successes, f=bt.failures)
+    print("Success: {s}, Failures: {f}".format(s=bt.successes, f=bt.failures))
 
 
 if __name__ == '__main__':

--- a/requests_throttler/throttler.py
+++ b/requests_throttler/throttler.py
@@ -385,7 +385,7 @@ class BaseThrottler(object):
             try:
                 self._enqueue_request(throttled_request)
             except FullRequestsPoolError as e:
-                throttled_request.exception(e)
+                throttled_request.exception = e
                 self._inc_failures()
         return throttled_request
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ AUTHOR_EMAIL_REGEX = r"^__author_email__\s=\s(?P<quote>['])(?P<author_email>.*)(
 packages = ['requests_throttler',
             'requests_throttler.tests']
 
-requires = ['requests>=2.1.0',
-            'futures>=2.1.5']
+requires = ['requests>=2.1.0']
 
 classifiers=[
     'Development Status :: 4 - Beta',
@@ -55,4 +54,5 @@ setup(name=title,
       package_data={'': ['LICENSE']},
       include_package_data=True,
       install_requires=requires,
+      extras_require={':python_version == "2.7"': ['futures >= 2.1.5']},
       classifiers=classifiers)


### PR DESCRIPTION
Currently when you try to pull this package in as a dependancy you get an exit 1 error code from pip, due to pulling in futures without it being a hard requirement, as well as the syntax errors below.

Please push a new package to PyPI after accepting this PR


```
  File "build/bdist.macosx-10.14-x86_64/egg/requests_throttler/example.py", line 35
    print r.response
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(r.response)?
```

```
This backport is meant only for Python 2.
It does not work on Python 3, and Python 3 users do not need it as the concurrent.futures package is available in the standard library.
For projects that work on both Python 2 and 3, the dependency needs to be conditional on the Python version, like so:
extras_require={':python_version == "2.7"': ['futures']}
error: Setup script exited with 1
```