### PR TITLE
Fixes logging by removing root logger and handlers from library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # RequestsThrottler: HTTP requests throttler
 
-_Fork of the original to remove log handlers that are interfering with my own logging efforts_
-
 RequestsThrottler is an Apache2 Licensed HTTP library, written in Python, and powered by futures and [Requests](https://github.com/kennethreitz/requests).
 See the [full documentation](http://pythonhosted.org/RequestsThrottler).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RequestsThrottler: HTTP requests throttler
 
+_Fork of the original to remove log handlers that are interfering with my own logging efforts_
+
 RequestsThrottler is an Apache2 Licensed HTTP library, written in Python, and powered by futures and [Requests](https://github.com/kennethreitz/requests).
 See the [full documentation](http://pythonhosted.org/RequestsThrottler).
 

--- a/requests_throttler/example.py
+++ b/requests_throttler/example.py
@@ -4,15 +4,17 @@ import requests
 
 from requests_throttler import BaseThrottler
 
+import logging
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--url', type=str, default='http://www.google.com',
+    parser.add_argument('--url', type=str, default='https://www.google.com',
                         dest='url',
                         help='Specifies the url to which send the requests')
     parser.add_argument('--delay', type=float, default=3, dest='delay',
                         help='Specifies the delay to use')
-    parser.add_argument('--num-reqs', type=int, default=5, dest='n_reqs',
+    parser.add_argument('--num-reqs', type=int, default=2, dest='n_reqs',
                         help='Specifies the number of requests to send')
     args = parser.parse_args()
     return {'url': args.url, 'delay': args.delay, 'n_reqs': args.n_reqs}
@@ -32,9 +34,9 @@ def main():
         throttled_requests = bt.multi_submit(reqs)
 
     for r in throttled_requests:
-        print r.response
+        print(r.response)
 
-    print "Success: {s}, Failures: {f}".format(s=bt.successes, f=bt.failures)
+    print("Success: {s}, Failures: {f}".format(s=bt.successes, f=bt.failures))
 
 
 if __name__ == '__main__':

--- a/requests_throttler/example.py
+++ b/requests_throttler/example.py
@@ -9,12 +9,12 @@ import logging
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--url', type=str, default='https://www.google.com',
+    parser.add_argument('--url', type=str, default='http://www.google.com',
                         dest='url',
                         help='Specifies the url to which send the requests')
     parser.add_argument('--delay', type=float, default=3, dest='delay',
                         help='Specifies the delay to use')
-    parser.add_argument('--num-reqs', type=int, default=2, dest='n_reqs',
+    parser.add_argument('--num-reqs', type=int, default=5, dest='n_reqs',
                         help='Specifies the number of requests to send')
     args = parser.parse_args()
     return {'url': args.url, 'delay': args.delay, 'n_reqs': args.n_reqs}

--- a/requests_throttler/settings.py
+++ b/requests_throttler/settings.py
@@ -1,7 +1,11 @@
-import logging
 
 ###----------------------###
 #---- Logging settings ----#
 ###----------------------###
 
 # Removed logging settings as this will be handled by the root logger
+# 
+# Logging is provided throughout the request throttling process and is sent to the root logger in the application that calls this library.
+# Instantiate a logger object using logger = logging.getLogger() - note that no argument is provided for a root logger.
+# This will act as the parent logger for this library's own logger and will control all logging output/formatting
+# The root logger will need to be configured with file and/or stream handlers as per: https://docs.python.org/3/howto/logging.html#logging-advanced-tutorial

--- a/requests_throttler/settings.py
+++ b/requests_throttler/settings.py
@@ -3,13 +3,5 @@ import logging
 ###----------------------###
 #---- Logging settings ----#
 ###----------------------###
-LOG_FORMAT_0=("[TID=%(thread)d - Thread=%(threadName)s - %(asctime)s - %(levelname)s - "
-              "%(module)s.%(funcName)s(%(lineno)d)]: %(message)s")
-LOG_FORMAT_1=("[Thread=%(threadName)s - %(asctime)s - %(levelname)s]: %(message)s")
-LOG_FORMAT_2=("[%(asctime)s - %(levelname)s]: %(message)s")
-LOG_FORMAT={logging.DEBUG: LOG_FORMAT_0,
-            logging.INFO: LOG_FORMAT_1,
-            logging.WARNING: LOG_FORMAT_2,
-            logging.ERROR: LOG_FORMAT_0,
-            logging.CRITICAL: LOG_FORMAT_0}
-DEFAULT_LOG_LEVEL=logging.INFO
+
+# Removed logging settings as this will be handled by the root logger

--- a/requests_throttler/throttler.py
+++ b/requests_throttler/throttler.py
@@ -8,6 +8,7 @@ This module contains the throttlers.
 
 """
 
+import logging
 import time
 import threading
 from collections import deque as queue
@@ -16,10 +17,10 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 
 from requests_throttler.utils import Timer
-from requests_throttler.utils import locked, get_logger
+from requests_throttler.utils import locked
 from requests_throttler.throttled_request import ThrottledRequest
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 THROTTLER_STATUS = ['initialized', 'running', 'waiting', 'paused', 'stopped', 'ending', 'ended']
 THROTTLER_STATUS_DEPENDENCIES = {'initialized': ['initialized', 'running', 'stopped'],

--- a/requests_throttler/utils.py
+++ b/requests_throttler/utils.py
@@ -9,13 +9,8 @@ This module provides some utilities used by other modules.
 """
 
 import time
-import logging
 import threading
 from functools import wraps
-
-from requests_throttler.settings import \
-    LOG_FORMAT, \
-    DEFAULT_LOG_LEVEL
 
 
 def locked(lock):
@@ -39,13 +34,6 @@ def locked(lock):
 
         return wrapper
     return _locked
-
-
-def get_logger(name, level=DEFAULT_LOG_LEVEL):
-    logging.basicConfig(format=LOG_FORMAT[level])
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    return logger
 
 
 class NoCheckpointSetError(Exception):


### PR DESCRIPTION
According to the [Python Logging Documentation](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library):
> **Note:** It is strongly advised that you do not log to the root logger in your library. Instead, use a logger with a unique and easily identifiable name, such as the __name__ for your library’s top-level package or module. Logging to the root logger will make it difficult or impossible for the application developer to configure the logging verbosity or handlers of your library as they wish.

and

> **Note:** It is strongly advised that you do not add any handlers other than [NullHandler](https://docs.python.org/3/library/logging.handlers.html#logging.NullHandler) to your library’s loggers. This is because the configuration of handlers is the prerogative of the application developer who uses your library. The application developer knows their target audience and what handlers are most appropriate for their application: if you add handlers ‘under the hood’, you might well interfere with their ability to carry out unit tests and deliver logs which suit their requirements.

The root logger accessed through `logging.basicConfig()` was removed along with the handler it automatically adds. This allows the application developer to have full control over the output/formatting of the logs. Without this, I had no control over the logs and ended up getting doubled logs sent to the console - this PR fixes that.

Also added the following:
- Updated Settings page with some basic instructions on how to configure the root logger in the developer's application
- Converted some of the print statements to Python 3 compatible syntax
- Added a Python .gitignore file